### PR TITLE
Omit isSelected prop for div

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
-    "classnames": "^2.2.1"
+    "classnames": "^2.2.1",
+    "object.omit": "^2.0.1"
   }
 }

--- a/src/option.js
+++ b/src/option.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var addClass = require('./add-class');
 var div = React.createFactory('div');
+var omit = require('object.omit');
 
 module.exports = React.createClass({
 
@@ -34,7 +35,7 @@ module.exports = React.createClass({
       props.className = addClass(props.className, 'ic-tokeninput-selected');
       props.ariaSelected = true;
     }
-    return div(props);
+    return div(omit(props, 'isSelected'));
   }
 
 });


### PR DESCRIPTION
Removes this warning from console

Warning: Unknown prop `isSelected` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in div